### PR TITLE
Fix for status bar icons not restoring correct mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This library is currently accessible via [JitPack](https://jitpack.io/#maxhvesse
 
 ```Gradle
 dependencies {
-    implementation 'com.github.maxhvesser:showroom:1.1.4-alpha'
+    implementation 'com.github.maxhvesser:showroom:1.1.5'
 }
 ```
 
@@ -106,7 +106,7 @@ override fun onCreate(savedInstanceState: Bundle?) {
 
 ### Releases
 
-The current release is [v1.1.4-alpha](https://github.com/maxhvesser/showroom/releases/tag/1.1.4-alpha) found at the respective link otherwise visit [releases](https://github.com/maxhvesser/showroom/releases) for the complete list.
+The current release is [v1.1.5](https://github.com/maxhvesser/showroom/releases/tag/1.1.5) found at the respective link otherwise visit [releases](https://github.com/maxhvesser/showroom/releases) for the complete list.
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This library is currently accessible via [JitPack](https://jitpack.io/#maxhvesse
 
 ```Gradle
 dependencies {
-    implementation 'com.github.maxhvesser:showroom:1.1.3-alpha'
+    implementation 'com.github.maxhvesser:showroom:1.1.4-alpha'
 }
 ```
 
@@ -106,7 +106,7 @@ override fun onCreate(savedInstanceState: Bundle?) {
 
 ### Releases
 
-The current release is [v1.1.3-alpha](https://github.com/maxhvesser/showroom/releases/tag/1.1.3-alpha) found at the respective link otherwise visit [releases](https://github.com/maxhvesser/showroom/releases) for the complete list.
+The current release is [v1.1.4-alpha](https://github.com/maxhvesser/showroom/releases/tag/1.1.4-alpha) found at the respective link otherwise visit [releases](https://github.com/maxhvesser/showroom/releases) for the complete list.
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 
 ## Showroom
 
-[![Build Status](https://travis-ci.com/MaxHvesser/showroom.svg?branch=master)](https://travis-ci.com/MaxHvesser/showroom)
+[![Build Status](https://travis-ci.com/MaxHvesser/showroom.svg?branch=master)](https://travis-ci.com/MaxHvesser/showroom) [![](https://jitpack.io/v/maxhvesser/showroom.svg)](https://jitpack.io/#maxhvesser/showroom)
+
 
 Showroom is an image gallery library built for Android. The aim of this library is to provide a single view component that provides an image gallery experience almost completely out-of-the-box with as little configuration from the consumer as possible. The project utilizes Kotlin and is very much in active development.
 

--- a/app/src/androidTest/java/no/mhl/showroom/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/no/mhl/showroom/ExampleInstrumentedTest.kt
@@ -1,12 +1,10 @@
 package no.mhl.showroom
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-
-import org.junit.Assert.*
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/app/src/main/java/no/mhl/showroom/ui/MainActivity.kt
+++ b/app/src/main/java/no/mhl/showroom/ui/MainActivity.kt
@@ -1,9 +1,9 @@
 package no.mhl.showroom.ui
 
 import android.os.Build
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.WindowManager
+import androidx.appcompat.app.AppCompatActivity
 import no.mhl.showroom.R
 
 class MainActivity : AppCompatActivity() {

--- a/app/src/main/res/layout/fragment_detail_ad.xml
+++ b/app/src/main/res/layout/fragment_detail_ad.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
@@ -9,8 +9,8 @@
         <item name="android:statusBarColor">@android:color/white</item>
         <item name="android:navigationBarColor">@android:color/white</item>
 
-        <item name="android:windowLightNavigationBar">true</item>
-        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar" tools:targetApi="27">true</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="23">true</item>
 
     </style>
 

--- a/app/src/test/java/no/mhl/showroom/ExampleUnitTest.kt
+++ b/app/src/test/java/no/mhl/showroom/ExampleUnitTest.kt
@@ -1,8 +1,7 @@
 package no.mhl.showroom
 
+import org.junit.Assert.assertEquals
 import org.junit.Test
-
-import org.junit.Assert.*
 
 /**
  * Example local unit test, which will execute on the development machine (host).

--- a/buildSrc/src/main/java/no/mhl/showroom/Dependencies.kt
+++ b/buildSrc/src/main/java/no/mhl/showroom/Dependencies.kt
@@ -12,12 +12,12 @@ object Libs {
         const val stdLib = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$version"
         const val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
 
-        const val ktx = "androidx.core:core-ktx:1.5.0-rc01"
+        const val ktx = "androidx.core:core-ktx:1.6.0"
     }
 
     // AndroidX
     object AndroidX {
-        const val appCompat = "androidx.appcompat:appcompat:1.2.0"
+        const val appCompat = "androidx.appcompat:appcompat:1.3.0"
         const val constraint = "androidx.constraintlayout:constraintlayout:2.0.4"
         const val recycler = "androidx.recyclerview:recyclerview:1.2.0"
         const val viewPager = "androidx.viewpager2:viewpager2:1.0.0"

--- a/showroom/src/androidTest/java/no/mhl/showroom/ExampleInstrumentedTest.kt
+++ b/showroom/src/androidTest/java/no/mhl/showroom/ExampleInstrumentedTest.kt
@@ -1,12 +1,10 @@
 package no.mhl.showroom
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-
-import org.junit.Assert.*
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/showroom/src/main/AndroidManifest.xml
+++ b/showroom/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
 <manifest package="no.mhl.showroom">
 
-    /
 </manifest>

--- a/showroom/src/main/AndroidManifest.xml
+++ b/showroom/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="no.mhl.showroom">
+<manifest package="no.mhl.showroom">
 
     /
 </manifest>

--- a/showroom/src/main/java/no/mhl/showroom/ui/Showroom.kt
+++ b/showroom/src/main/java/no/mhl/showroom/ui/Showroom.kt
@@ -7,7 +7,7 @@ import android.graphics.Color
 import android.graphics.Typeface
 import android.os.Build
 import android.util.AttributeSet
-import android.view.*
+import android.view.LayoutInflater
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.TextView
@@ -34,14 +34,13 @@ import no.mhl.showroom.data.preloadUpcomingImages
 import no.mhl.showroom.model.GalleryImage
 import no.mhl.showroom.ui.adapter.ImagePagerAdapter
 import no.mhl.showroom.ui.adapter.ThumbnailRecyclerAdapter
-import no.mhl.showroom.ui.adapter.viewholder.ImagePagerViewHolder
 import no.mhl.showroom.ui.views.InfiniteViewPager2
 import no.mhl.showroom.util.setCount
 import no.mhl.showroom.util.setDescription
 import okhttp3.OkHttpClient
 
 
-class Showroom
+class  Showroom
 constructor(context: Context, attrs: AttributeSet?) : FrameLayout(context, attrs) {
 
     // region View Properties

--- a/showroom/src/main/java/no/mhl/showroom/ui/ShowroomLite.kt
+++ b/showroom/src/main/java/no/mhl/showroom/ui/ShowroomLite.kt
@@ -16,8 +16,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import no.mhl.showroom.R
-import no.mhl.showroom.model.GalleryImage
 import no.mhl.showroom.data.preloadUpcomingImages
+import no.mhl.showroom.model.GalleryImage
 import no.mhl.showroom.ui.adapter.ImageLitePagerAdapter
 import no.mhl.showroom.util.setCount
 import no.mhl.showroom.util.setDescription

--- a/showroom/src/main/java/no/mhl/showroom/ui/adapter/ImagePagerAdapter.kt
+++ b/showroom/src/main/java/no/mhl/showroom/ui/adapter/ImagePagerAdapter.kt
@@ -1,6 +1,7 @@
 package no.mhl.showroom.ui.adapter
 
-import android.view.*
+import android.view.LayoutInflater
+import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import no.mhl.showroom.R
 import no.mhl.showroom.model.GalleryImage

--- a/showroom/src/main/java/no/mhl/showroom/ui/views/InfiniteViewPager2.kt
+++ b/showroom/src/main/java/no/mhl/showroom/ui/views/InfiniteViewPager2.kt
@@ -7,8 +7,8 @@ import android.widget.FrameLayout
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
-import no.mhl.showroom.R
 import androidx.viewpager2.widget.ViewPager2.OnPageChangeCallback
+import no.mhl.showroom.R
 
 class InfiniteViewPager2(
     context: Context,

--- a/showroom/src/main/res/values/dimens.xml
+++ b/showroom/src/main/res/values/dimens.xml
@@ -9,7 +9,6 @@
     <!-- Margin -->
     <dimen name="margin_large">32dp</dimen>
     <dimen name="margin_normal">16dp</dimen>
-    <dimen name="margin_small">8dp</dimen>
     <dimen name="margin_minimum">2dp</dimen>
 
     <!-- Padding -->

--- a/showroom/src/main/res/values/strings.xml
+++ b/showroom/src/main/res/values/strings.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
-    <!-- region Showroom -->
-    <!-- endregion -->
-
+    
     <!-- region Action Button -->
     <string name="action_button_content_description">Action Button</string>
     <!-- endregion -->

--- a/showroom/src/main/res/values/strings.xml
+++ b/showroom/src/main/res/values/strings.xml
@@ -2,7 +2,6 @@
 <resources>
 
     <!-- region Showroom -->
-    <string name="go_to_first_text">Go To First</string>
     <!-- endregion -->
 
     <!-- region Action Button -->

--- a/showroom/src/main/res/values/styles.xml
+++ b/showroom/src/main/res/values/styles.xml
@@ -1,10 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <!-- Toolbar -->
-    <style name="Toolbar" parent="Widget.AppCompat.Toolbar">
-        <item name="colorControlNormal">@android:color/white</item>
-        <item name="colorControlHighlight">#80FFFFFF</item>
-    </style>
-
 </resources>

--- a/showroom/src/test/java/no/mhl/showroom/ExampleUnitTest.kt
+++ b/showroom/src/test/java/no/mhl/showroom/ExampleUnitTest.kt
@@ -1,8 +1,7 @@
 package no.mhl.showroom
 
+import org.junit.Assert.assertEquals
 import org.junit.Test
-
-import org.junit.Assert.*
 
 /**
  * Example local unit test, which will execute on the development machine (host).


### PR DESCRIPTION
Please take a look at the [originally reported issue](https://www.youtube.com/watch?v=NyLLSNk0Fg4&amp;ab_channel=OlavBirkeland).

A bug is present whereby when the user enters the image gallery (whilst in Dark Mode) upon exiting, the status bar icons change to Dark Mode, this is firstly caused because the logic to decide if the status bar mode should be Light/Dark is missing but the real culprit behind why this functionality is due to a [currently open platform bug](https://issuetracker.google.com/issues/180881870).

The above platform bug causes an issue where `isAppearanceLightStatusBars` reports back inconsistently/incorrectly. A suggested workaround has been given in the bug report and this PR is to merge in the workaround that has been made upstream. 

The workaround simply involves using the now deprecated way of detecting Light/Dark modes as seen in the `isStatusBarLight()` function, this is, unfortunately, unavoidable for now and when a fix is made for the aforementioned bug then this function will be updated.

Further to the above fix, the following is included in this PR;

- Updated `AppCompat` and `KTX` dependencies
- Optimized imports
- Removed unused resources