### PR TITLE
Scroll to thumbnail at initial position

### DIFF
--- a/showroom/src/main/java/no/mhl/showroom/ui/Showroom.kt
+++ b/showroom/src/main/java/no/mhl/showroom/ui/Showroom.kt
@@ -234,6 +234,7 @@ constructor(context: Context, attrs: AttributeSet?) : FrameLayout(context, attrs
         }
 
         setThumbnailAsSelected(initialPosition)
+        thumbnailRecycler.scrollToPosition(initialPosition)
     }
 
     private fun setupToolbar() {


### PR DESCRIPTION
Given that it's possible to initialise Showroom with any item position, we should also adjust the thumbnail scroll accordingly.